### PR TITLE
make: fix macos install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,5 @@ build: example-plugin.so
 	@echo "Built against" $(IPFS_VERSION)
 
 install: build
-	install -Dm700 example-plugin.so "$(IPFS_PATH)/plugins/example-plugin.so"
+	mkdir -p "$(IPFS_PATH)/plugins/"
+	cp example-plugin.so "$(IPFS_PATH)/plugins/example-plugin.so"


### PR DESCRIPTION
`install` isn't cross platform